### PR TITLE
Update dockerfile to build off of nfcore/base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM continuumio/miniconda3:latest
+FROM nfcore/base:1.9
 LABEL authors="Jack Kamm and Samantha Hao" \
-      description="Docker image containing all requirements for sars-cov-2 MSSPE pipeline"
+      description="Docker image containing all software requirements for the nf-core/msspe pipeline"
 
+# Install the conda environment
 COPY environment.yaml /
-RUN /opt/conda/bin/conda env create -f /environment.yaml && /opt/conda/bin/conda clean -a
-ENV PATH /opt/conda/envs/sc2-msspe/bin:$PATH
+RUN conda env create -f /environment.yaml && conda clean -a
+
+# Add conda installation dir to PATH (instead of doing 'conda activate')
+ENV PATH /opt/conda/envs/sc2-msspe/bin/:$PATH
+
+# Dump the details of the installed packages to a file for posterity
+RUN conda env export --name nf-core-msspe-1.0dev > nf-core-msspe-1.0dev.yaml


### PR DESCRIPTION
Adding test data template updates to https://github.com/czbiohub/sc2-msspe-bioinfo/pull/2 and ran into this error, which is a result of the base Docker image.

```
(base)
 Thu 26 Mar - 14:11  ~/code/sc2-msspe-bioinfo   template-updates 1☀ 1● 
  nextflow run -profile test,docker .
N E X T F L O W  ~  version 20.01.0-rc1
Launching `./main.nf` [agitated_bohr] - revision: a9e328ff85
WARN: Access to undefined parameter `genome` -- Initialise it to a default value eg. `params.genome = some_value`
----------------------------------------------------
                                        ,--./,-.
        ___     __   __   __   ___     /,-._.--~'
  |\ | |__  __ /  ` /  \ |__) |__         }  {
  | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                        `._,._,'
  nf-core/msspe v1.0dev
----------------------------------------------------
Run Name          : agitated_bohr
Reads             : data/*R{1,2}_001.fastq.gz
Fasta Ref         : https://github.com/czbiohub/test-datasets/raw/msspe/reference/MN908947.3.fa
Data Type         : Paired-End
Max Resources     : 6 GB memory, 2 cpus, 2d time per job
Container         : docker - czbiohub/msspe:dev
Output dir        : results
Launch dir        : /Users/olgabot/code/sc2-msspe-bioinfo
Working dir       : /Users/olgabot/code/sc2-msspe-bioinfo/work
Script dir        : /Users/olgabot/code/sc2-msspe-bioinfo
User              : olgabot
Config Profile    : test,docker
Config Description: Minimal test dataset to check pipeline function
----------------------------------------------------
executor >  local (3)
[e8/243879] process > get_software_versions [100%] 1 of 1, failed: 1 ✘
[-        ] process > trimReads             -
[-        ] process > alignReads            -
[-        ] process > trimPrimers           -
[-        ] process > makeConsensus         -
[7f/b28743] process > multiqc               [100%] 1 of 1, failed: 1 ✘
[de/5db7ef] process > output_documentation  [100%] 1 of 1, failed: 1 ✘
Execution cancelled -- Finishing pending tasks before exit
-[nf-core/msspe] Pipeline completed with errors-
Error executing process > 'get_software_versions'

Caused by:
  Process `get_software_versions` terminated with an error exit status (1)

Command executed:

  echo 1.0dev > v_pipeline.txt
  echo 20.01.0-rc1 > v_nextflow.txt
  fastqc --version > v_fastqc.txt
  multiqc --version > v_multiqc.txt
  scrape_software_versions.py &> software_versions_mqc.yaml

Command exit status:
  1

Command output:
  (empty)

Command error:
  Unable to find image 'czbiohub/msspe:dev' locally
  dev: Pulling from czbiohub/msspe
  68ced04f60ab: Pulling fs layer
  9c388eb6d33c: Pulling fs layer
  96cf53b3a9dd: Pulling fs layer
  e797e13400e0: Pulling fs layer
  1cbcef50c27b: Pulling fs layer
  1cbcef50c27b: Waiting
  68ced04f60ab: Verifying Checksum
  68ced04f60ab: Download complete
  e797e13400e0: Verifying Checksum
  e797e13400e0: Download complete
  96cf53b3a9dd: Verifying Checksum
  96cf53b3a9dd: Download complete
  9c388eb6d33c: Verifying Checksum
  9c388eb6d33c: Download complete
  68ced04f60ab: Pull complete
  9c388eb6d33c: Pull complete
  96cf53b3a9dd: Pull complete
  1cbcef50c27b: Download complete
  e797e13400e0: Pull complete
  1cbcef50c27b: Pull complete
  Digest: sha256:2bc6dbc4358a74bfab6baf0f36032e475bbb945fefac0b417662d8db9fe78cb0
  Status: Downloaded newer image for czbiohub/msspe:dev
  Command 'ps' required by nextflow to collect task metrics cannot be found

Work dir:
  /Users/olgabot/code/sc2-msspe-bioinfo/work/e8/243879e745cdd86935a154a02c3f32

Tip: you can try to figure out what's wrong by changing to the process work dir and showing the script file named `.command.sh

````