### PR TITLE
Samlhao/pull blast result

### DIFF
--- a/bin/get_top_hit.py
+++ b/bin/get_top_hit.py
@@ -30,17 +30,17 @@ if len(SeqIO.read(args.assembly, 'fasta')) > 0:
     if df['length'].max() < args.minLength/2:
         # One HSP should extend to at least half the minimum length since we only expect a few SNPS
         # Otherwise the alignment is probably bad
-        shutil.copyfile(args.default, 'nearest_blast.fasta')
+        shutil.copyfile(args.default, f'{args.sampleName}_nearest_blast.fasta')
     else:
         try:
             # In case the TSV is empty
             top_hit = df[df['bitscore']==df['bitscore'].max()]['sacc'][0]
             sequences = SeqIO.index(args.sequences, 'fasta')
             top_hit_seq = sequences[top_hit]
-            SeqIO.write(top_hit_seq, 'nearest_blast.fasta', 'fasta')
+            SeqIO.write(top_hit_seq, f'{args.sampleName}_nearest_blast.fasta', 'fasta')
         except IndexError:
-            shutil.copyfile(args.default, 'nearest_blast.fasta')
+            shutil.copyfile(args.default, f'{args.sampleName}_nearest_blast.fasta')
 else:
-    shutil.copyfile(args.default, 'nearest_blast.fasta')
+    shutil.copyfile(args.default, f'{args.sampleName}_nearest_blast.fasta')
     with open(f'{args.sampleName}.blast.tsv', 'w+') as f:
         f.write('Empty query sequence.')

--- a/environment.yaml
+++ b/environment.yaml
@@ -20,3 +20,4 @@ dependencies:
   - biopython=1.76 
   - pysam=0.15.4
   - blast=2.9.0
+  - seqkit=0.12.0

--- a/main.nf
+++ b/main.nf
@@ -198,8 +198,7 @@ reads_ch.into { minimap2_reads_in; quast_reads }
 
 process alignReads {
     tag { sampleName }
-
-    cpus 4
+    label 'process_medium'
 
     input:
     tuple(sampleName, file(reads)) from minimap2_reads_in
@@ -211,7 +210,7 @@ process alignReads {
     script:
     """
     minimap2 -ax sr -R '@RG\\tID:${sampleName}\\tSM:${sampleName}' ${ref_fasta} ${reads} |
-      samtools sort -@ 2 -O bam -o ${sampleName}.bam
+      samtools sort -@ ${task.cpus-1} -O bam -o ${sampleName}.bam
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -697,7 +697,7 @@ process filterStrains {
     if (params.subsample_gisaid)
     """
     cat ${included_samples} >> ${include_file}
-    cat ${include_fastas} >> ${sequences}
+    cat ${included_fastas} >> ${sequences}
     augur filter \
             --sequences ${sequences} \
             --metadata ${metadata} \

--- a/main.nf
+++ b/main.nf
@@ -694,7 +694,6 @@ process filterStrains {
 
     script:
     String exclude_where = "date='2020' date='2020-01-XX' date='2020-02-XX' date='2020-03-XX' date='2020-04-XX' date='2020-01' date='2020-02' date='2020-03' date='2020-04'"
-    if (params.subsample_gisaid)
     """
     cat ${included_samples} >> ${include_file}
     cat ${included_fastas} >> ${sequences}
@@ -706,23 +705,8 @@ process filterStrains {
             --exclude ${exclude_file} \
             --exclude-where ${exclude_where} \
             --min-length ${params.minLength} \
-            --group-by division year month \
-            --sequences-per-group 1 \
             --output filtered.fasta
     """
-
-    else
-    """
-    augur filter \
-            --sequences ${sequences} \
-            --metadata ${metadata} \
-            --include ${include_file} \
-            --exclude ${exclude_file} \
-            --exclude-where ${exclude_where} \
-            --min-length ${params.minLength} \
-            --output filtered.fasta
-    """
-
 }
 
 process alignSequences {

--- a/main.nf
+++ b/main.nf
@@ -32,7 +32,7 @@ def helpMessage() {
 
     Nextstrain options:
       --nextstrain_ncov             Path to nextstrain/ncov directory (default: fetches from github)
-      --subsample  N                Subsample nextstrain sequences to N (default: 100)
+      --subsample  N                Subsample nextstrain sequences to N (set to false if no subsampling, default: 100)
 
     Other options:
       --outdir                      The output directory where the results will be saved

--- a/main.nf
+++ b/main.nf
@@ -698,8 +698,9 @@ process filterStrains {
     """
     cat ${included_samples} >> ${include_file}
     cat ${included_fastas} >> ${sequences}
+    seqkit rmdup ${sequences} > deduped_sequences.fasta
     augur filter \
-            --sequences ${sequences} \
+            --sequences deduped_sequences.fasta \
             --metadata ${metadata} \
             --include ${include_file} \
             --exclude ${exclude_file} \

--- a/main.nf
+++ b/main.nf
@@ -292,7 +292,7 @@ process blastConsensus {
 
     output:
     path("${sampleName}.blast.tsv")
-    tuple(sampleName, path("${sampleName}_nearest_blast.fasta")) into nearest_neighbor, collectnearest_ch)
+    tuple(sampleName, path("${sampleName}_nearest_blast.fasta")) into (nearest_neighbor, collectnearest_ch)
 
     script:
     """

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,7 +52,7 @@ params {
 }
 
 process {
-  container = 'czbiohub/sc2-msspe:dev'
+  container = 'czbiohub/sc2-msspe'
   withLabel:'nextstrain' {
     container = 'nextstrain/base:latest'
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,6 +38,7 @@ params {
 // Nextstrain data
   nextstrain_sequences = ""
   nextstrain_ncov = "https://raw.githubusercontent.com/nextstrain/ncov/master/"
+  subsample = 100
 
 // detect intrahost variants
    intrahost_variants = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,7 +52,7 @@ params {
 }
 
 process {
-  container = 'czbiohub/sc2-msspe'
+  container = 'czbiohub/sc2-msspe:dev'
   withLabel:'nextstrain' {
     container = 'nextstrain/base:latest'
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -59,6 +59,9 @@ process {
   withLabel:'process_large' {
     cpus = 8
   }
+  withLabel:'process_medium' {
+    cpus = 4
+  }
 }
 
 // Profiles


### PR DESCRIPTION
- subsampling nextstrain sequences now build into the pipeline using `seqtk`
    - will produce same subsample given the same nextstrain fasta
- always includes nearest blast sequences in `augur filter`
- note: we can handpick sequences to include by editing `include.txt` in a local copy of `ncov`