### PR TITLE
Samlhao/paired reads assembly

### DIFF
--- a/call_consensus.nf
+++ b/call_consensus.nf
@@ -262,9 +262,9 @@ process extractSC2 {
 
   script:
   """
+  samtools sort -n ${bam} |
   samtools fastq -1 ${sampleName}_sc2_1.fq.gz -2 ${sampleName}_sc2_2.fq.gz \
-    -f 1 -F 12 -0 /dev/null -s /dev/null -n -c 6 -@ ${task.cpus-1}\
-    ${bam}
+    -f 1 -F 12 -0 /dev/null -s /dev/null -n -c 6 -@ ${task.cpus-1}
   """
 }
 

--- a/call_consensus.nf
+++ b/call_consensus.nf
@@ -243,7 +243,7 @@ process trimPrimers {
     samtools index ivar.bam
     ivar trim -e -i ivar.bam -b ${primer_bed} -p ivar.out
     samtools sort -O bam -o ${sampleName}.primertrimmed.unfiltered.bam ivar.out.bam
-    samtools view -f 1 -F 12 -bo ${sampleName}.primertrimmed.unfiltered.bam ${sampleName}.primertrimmed.bam
+    samtools view -f 1 -F 12 -bo ${sampleName}.primertrimmed.bam ${sampleName}.primertrimmed.unfiltered.bam
     samtools index ${sampleName}.primertrimmed.bam
     """
 }

--- a/call_consensus.nf
+++ b/call_consensus.nf
@@ -262,7 +262,7 @@ process extractSC2 {
 
   script:
   """
-  samtools sort -n ${bam} |
+  samtools sort -n ${bam} | \
   samtools fastq -1 ${sampleName}_sc2_1.fq.gz -2 ${sampleName}_sc2_2.fq.gz \
     -f 1 -F 12 -0 /dev/null -s /dev/null -n -c 6 -@ ${task.cpus-1}
   """

--- a/call_consensus.nf
+++ b/call_consensus.nf
@@ -262,9 +262,9 @@ process extractSC2 {
 
   script:
   """
-  samtools sort -n ${bam} | \
-  samtools fastq -1 ${sampleName}_sc2_1.fq.gz -2 ${sampleName}_sc2_2.fq.gz \
-    -f 1 -F 12 -0 /dev/null -s /dev/null -n -c 6 -@ ${task.cpus-1}
+  samtools sort -n ${bam} |
+    samtools fastq -1 ${sampleName}_sc2_1.fq.gz -2 ${sampleName}_sc2_2.fq.gz \
+    -f 1 -F 12 -0 /dev/null -s /dev/null -n -c 6 -@ ${task.cpus-1} -
   """
 }
 

--- a/call_consensus.nf
+++ b/call_consensus.nf
@@ -242,7 +242,8 @@ process trimPrimers {
     samtools view -F4 -q ${params.samQualThreshold} -o ivar.bam ${alignment}
     samtools index ivar.bam
     ivar trim -e -i ivar.bam -b ${primer_bed} -p ivar.out
-    samtools sort -O bam -o ${sampleName}.primertrimmed.bam ivar.out.bam
+    samtools sort -O bam -o ${sampleName}.primertrimmed.unfiltered.bam ivar.out.bam
+    samtools view -f 1 -F 12 -bo ${sampleName}.primertrimmed.unfiltered.bam ${sampleName}.primertrimmed.bam
     samtools index ${sampleName}.primertrimmed.bam
     """
 }
@@ -295,9 +296,8 @@ process makeConsensus {
 
   script:
   """
-  samtools view -f 1 -F 12 -bo filtered.bam ${bam}
-  samtools index filtered.bam
-  samtools mpileup -A -d ${params.mpileupDepth} -Q0 filtered.bam |
+  samtools index ${bam}
+  samtools mpileup -A -d ${params.mpileupDepth} -Q0 ${bam} |
     ivar consensus -q ${params.ivarQualThreshold} -t ${params.ivarFreqThreshold} -m ${params.minDepth} -n N -p ${sampleName}.primertrimmed.consensus
         echo '>${sampleName}' > ${sampleName}.consensus.fa
         seqtk seq -l 50 ${sampleName}.primertrimmed.consensus.fa | tail -n +2 >> ${sampleName}.consensus.fa

--- a/call_consensus.nf
+++ b/call_consensus.nf
@@ -295,8 +295,9 @@ process makeConsensus {
 
   script:
   """
-        samtools index ${bam}
-  samtools mpileup -A -d ${params.mpileupDepth} -Q0 ${bam} |
+  samtools view -f 1 -F 12 -bo filtered.bam ${bam}
+  samtools index filtered.bam
+  samtools mpileup -A -d ${params.mpileupDepth} -Q0 filtered.bam |
     ivar consensus -q ${params.ivarQualThreshold} -t ${params.ivarFreqThreshold} -m ${params.minDepth} -n N -p ${sampleName}.primertrimmed.consensus
         echo '>${sampleName}' > ${sampleName}.consensus.fa
         seqtk seq -l 50 ${sampleName}.primertrimmed.consensus.fa | tail -n +2 >> ${sampleName}.consensus.fa

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,9 @@ params {
 
   exclude_samples = ""
 
+// call consensus defaults
+  keep_ambiguous = false
+  
 // iVar defaults
   ivarQualThreshold = 20
   ivarFreqThreshold = 0.6


### PR DESCRIPTION
- added process to extract sc2 reads by only taking reads with bit flags 1 and without 4 or 8 (`-f 1 -F 12`
- use only these reads to call the consensus by default
  * parameter `--keep-ambiguous` will use keep the singletons, supplementaries, and secondaries
- @jackkamm I'm not totally sure if we should be also be asking for proper pairing and excluding supplementary alignments, `-f` and `-F` are mildly mysterious to me