### PR TITLE
Add option to run under AWS Batch

### DIFF
--- a/conf/awsbatch.config
+++ b/conf/awsbatch.config
@@ -1,5 +1,4 @@
 aws.region = 'us-west-2'
 process.executor = 'awsbatch'
 process.queue = 'default-971039e0-830c-11e9-9e0b-02c5b84a8036'
-process.container = 'czbiohub/sc2-msspe'
 aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'

--- a/conf/awsbatch.config
+++ b/conf/awsbatch.config
@@ -1,0 +1,5 @@
+aws.region = 'us-west-2'
+process.executor = 'awsbatch'
+process.queue = 'default-971039e0-830c-11e9-9e0b-02c5b84a8036'
+process.container = 'czbiohub/sc2-msspe'
+aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'

--- a/conf/test.config
+++ b/conf/test.config
@@ -22,6 +22,4 @@ params {
   // originally from https://genexa.ch/sars2-bioinformatics-resources/
   // TODO: make publically accessible
   kraken2_db = 's3://jackkamm/covidseq/kraken2_h+v_20200319/'
-
-  blast_sequences = 'https://raw.githubusercontent.com/nextstrain/ncov/master/example_data/sequences.fasta'
 }

--- a/conf/test_awsbatch.config
+++ b/conf/test_awsbatch.config
@@ -1,0 +1,13 @@
+
+includeConfig 'awsbatch.config'
+
+params {
+  outdir = 's3://czb-covid-results/test/test_awsbatch'
+
+  // TODO: generate & use publicly-accessible, IRB-compliant test samples
+  reads = 's3://jackkamm/covidseq/fastqs/test/*_R{1,2}_001.fastq.gz'
+
+  // originally from https://genexa.ch/sars2-bioinformatics-resources/
+  // TODO: make publically accessible
+  kraken2_db = 's3://jackkamm/covidseq/kraken2_h+v_20200319/'
+}

--- a/environment.yaml
+++ b/environment.yaml
@@ -21,5 +21,13 @@ dependencies:
   - pysam=0.15.4
   - blast=2.9.0
   - seqkit=0.12.0
-  - pip
   - git
+  - mafft
+  - raxml
+  - fasttree
+  - iqtree
+  - vcftools
+  - snakemake
+  - pip
+  - pip:
+    - nextstrain-augur

--- a/nextflow.config
+++ b/nextflow.config
@@ -110,9 +110,6 @@ process {
 
   container = 'czbiohub/sc2-msspe'
 
-  withLabel:'nextstrain' {
-    container = 'nextstrain/base:latest'
-  }
   withLabel:'process_large' {
     cpus = { check_max(8, 'cpus') }
     memory = { check_max(16.GB, 'memory') }

--- a/nextflow.config
+++ b/nextflow.config
@@ -2,6 +2,11 @@ params {
   outdir = 'results'
   help = false
 
+  // Defaults only, expecting to be overwritten
+  max_memory = 128.GB
+  max_cpus = 16
+  max_time = 240.h
+
   ref = "$baseDir/data/MN908947.3.fa"
   ref_gb = "$baseDir/data/MN908947.3.gb"
   primers = "$baseDir/data/SARS-COV-2_spikePrimers.bed"
@@ -61,28 +66,86 @@ params {
 
 }
 
+// Function to ensure that resource requirements don't go beyond
+// a maximum limit
+def check_max(obj, type) {
+  if (type == 'memory') {
+    try {
+      if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
+        return params.max_memory as nextflow.util.MemoryUnit
+      else
+        return obj
+    } catch (all) {
+      println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
+      return obj
+    }
+  } else if (type == 'time') {
+    try {
+      if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
+        return params.max_time as nextflow.util.Duration
+      else
+        return obj
+    } catch (all) {
+      println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
+      return obj
+    }
+  } else if (type == 'cpus') {
+    try {
+      return Math.min( obj, params.max_cpus as int )
+    } catch (all) {
+      println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
+      return obj
+    }
+  }
+}
+
 process {
+
+  cpus = { check_max( 2 * task.attempt, 'cpus') }
+  memory = { check_max( 4.GB * task.attempt, 'memory') }
+  time = { check_max( 1.h * task.attempt, 'time') }
+
+  //maxRetries = 3
+  //maxErrors = '-1'
+
   container = 'czbiohub/sc2-msspe'
+
   withLabel:'nextstrain' {
     container = 'nextstrain/base:latest'
   }
   withLabel:'process_large' {
-    cpus = 8
+    cpus = { check_max(8, 'cpus') }
+    memory = { check_max(16.GB, 'memory') }
+    time = { check_max (4.h, 'time')}
   }
   withLabel:'process_medium' {
-    cpus = 4
+    cpus = { check_max(4, 'cpus') }
+    memory = { check_max(8.GB, 'memory') }
+    time = { check_max (2.h, 'time')}
   }
+  withLabel:'process_small' {
+    cpus = { check_max(2, 'cpus') }
+    memory = { check_max(4.GB, 'memory') }
+    time = { check_max (1.h, 'time')}
+  }
+  withLabel:'process_tiny' {
+    cpus = { check_max(1, 'cpus') }
+    memory = { check_max(2.GB, 'memory') }
+    time = { check_max (1.h, 'time')}
+  }
+
 }
 
 // Profiles
 profiles {
-  awsbatch { includeConfig 'conf/aws.config' }
   conda { process.conda = "$baseDir/environment.yaml" }
   debug { process.beforeScript = 'echo $HOSTNAME' }
   docker { docker.enabled = true }
   singularity { singularity.enabled = true }
+  awsbatch { includeConfig 'conf/awsbatch.config' }
   test { includeConfig 'conf/test.config' }
   test_nextstrain { includeConfig 'conf/test_nextstrain.config' }
   test_fasta_reads { includeConfig 'conf/test_fasta_reads.config' }
+  test_awsbatch { includeConfig 'conf/test_awsbatch.config' }
   fasta_reads { includeConfig 'conf/fasta_reads.config' }
 }

--- a/run_analysis.nf
+++ b/run_analysis.nf
@@ -452,7 +452,6 @@ else {
 }
 
 process firstFilter {
-  label "nextstrain"
   publishDir "${params.outdir}/nextstrain/results", mode: 'copy'
 
   input:
@@ -482,7 +481,6 @@ process firstFilter {
 
 process alignSequences {
   label "process_large"
-  label "nextstrain"
   publishDir "${params.outdir}/nextstrain/results", mode: 'copy'
 
 
@@ -507,7 +505,6 @@ process alignSequences {
 }
 
 process extractSampleSequences {
-  label 'nextstrain'
   publishDir "${params.outdir}/nextstrain/results", mode: 'copy'
 
 
@@ -552,7 +549,6 @@ process makePriorities {
 }
 
 process filterStrains {
-    label 'nextstrain'
     publishDir "${params.outdir}/nextstrain/results", mode: 'copy'
 
     input:
@@ -581,7 +577,6 @@ process filterStrains {
 }
 
 process buildTree {
-    label 'nextstrain'
     publishDir "${params.outdir}/nextstrain/results", mode: 'copy'
 
     cpus 4
@@ -603,7 +598,6 @@ process buildTree {
 }
 
 process refineTree {
-    label 'nextstrain'
     publishDir "${params.outdir}/nextstrain/results", mode: 'copy'
 
     input:
@@ -637,7 +631,6 @@ process refineTree {
 }
 
 process ancestralSequences {
-    label 'nextstrain'
     publishDir "${params.outdir}/nextstrain/results", mode: 'copy'
 
     input:
@@ -659,7 +652,6 @@ process ancestralSequences {
 }
 
 process translateSequences {
-    label 'nextstrain'
     publishDir "${params.outdir}/nextstrain/results", mode: 'copy'
 
     input:
@@ -682,7 +674,6 @@ process translateSequences {
 
 
 process inferTraits {
-    label 'nextstrain'
     publishDir "${params.outdir}/nextstrain/results", mode: 'copy'
 
     input:
@@ -705,7 +696,6 @@ process inferTraits {
 }
 
 process addClades {
-    label 'nextstrain'
     publishDir "${params.outdir}/nextstrain/results", mode: 'copy'
 
     input:
@@ -727,7 +717,6 @@ process addClades {
 }
 
 process tipFrequencies {
-    label 'nextstrain'
     publishDir "${params.outdir}/nextstrain/auspice", mode: 'copy'
 
     input:
@@ -752,7 +741,6 @@ process tipFrequencies {
 }
 
 process exportData {
-    label 'nextstrain'
     publishDir "${params.outdir}/nextstrain/auspice", mode: 'copy'
 
     input:


### PR DESCRIPTION
This PR allows us to run the `call_consensus.nf` under AWS Batch. I tested on both the small test datasets, as well as the COMET SEQ001 plate.

Outstanding issues:
- Couldn't get `run_analyses.nf` to work, in particular processes that use the Nextstrain container failed with the below message. 
```
bash: /home/ec2-user/miniconda/bin/aws: /home/ec2-user/miniconda/bin/python: bad interpreter: No such file or directory
``` 
While it would be nice to get nextstrain working with Batch, I think it less essential for now, especially since we might change the way we invoke Nextstrain to use their `ncov` repo directly.
- Currently this is set up to use our default nextflow queue. We should use a dedicated covid queue so that resources get tagged as such. Working on getting that set up now.