### PR TITLE
Rename samples

### DIFF
--- a/bin/extract_new_variants.py
+++ b/bin/extract_new_variants.py
@@ -12,7 +12,7 @@ def label_reference_subtree(ll, new_sample_string):
     for node in ll.Objects:
         node.traits['ref'] = False
 
-    ref_nodes = ll.getExternal(lambda k: new_sample_string != k.traits['node_attrs']['submitting_lab']['value'])
+    ref_nodes = ll.getExternal(lambda k: new_sample_string not in k.traits['node_attrs']['submitting_lab']['value'])
     while len(ref_nodes) > 0:
         node = ref_nodes.pop()
         node.traits['ref'] = True

--- a/bin/get_top_hit.py
+++ b/bin/get_top_hit.py
@@ -30,9 +30,9 @@ if args.metadata:
         else:
             return row['country']
     division_metadata['level'] = division_metadata.apply(check_level, axis=1)
-
-# check that the query is not empty
-if len(SeqIO.read(args.assembly, 'fasta')) > 0:
+sequence = SeqIO.read(args.assembly, 'fasta')
+# check that the query has enough sequence to BLAST
+if len(sequence)-sequence.seq.count('N') > 20:
     subprocess.run(" ".join(["blastn", "-db", "blast_seqs.nt", "-query",
                     args.assembly, "-num_threads", "32", "-out",
                     f"{args.sampleName}.blast.tsv", "-outfmt", "'6",

--- a/bin/make_nextstrain_input.py
+++ b/bin/make_nextstrain_input.py
@@ -29,6 +29,7 @@ sequences = list(SeqIO.parse(args.new_sequences, 'fasta'))
 old_metadata = pd.read_csv(args.prev_metadata, sep='\t')
 if args.new_metadata:
     new_metadata = pd.read_csv(args.new_metadata, sep='\t')
+    new_metadata = new_metadata[~new_metadata['strain'].isin(old_metadata['strain'])]
 else:
     new_metadata = pd.DataFrame()
 

--- a/bin/rename_samples.py
+++ b/bin/rename_samples.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import pandas as pd
+from Bio import SeqIO
+import re
+import argparse
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--public_identifiers')
+parser.add_argument('--in_fa')
+args = parser.parse_args()
+
+df = pd.read_csv(args.public_identifiers, sep='\t')
+
+sequences = list(SeqIO.parse(args.in_fa, 'fasta'))
+new_sequences = []
+for seq in sequences:
+    try:
+        publicID = df[df['sample_name']==seq.id]['gisaid_name'].values[0]
+        publicID = re.search(pattern='hCoV-19/(.*)$', string=publicID).group(1)
+    except IndexError:
+        publicID = seq.id
+    seq.id = publicID
+    seq.name = publicID
+    seq.description = publicID
+    new_sequences.append(seq)
+SeqIO.write(new_sequences, 'renamed_sequences.fasta', 'fasta')

--- a/conf/test_nextstrain.config
+++ b/conf/test_nextstrain.config
@@ -13,6 +13,7 @@ params {
   sequences_per_group_1 = 3
   sequences_per_group_2 = 2
   existing_alignment = "$baseDir/data/test/prev_alignment.fasta"
+  public_identifiers = "$baseDir/data/test/test_public_identifiers.tsv"
 
 }
 

--- a/data/test/test_public_identifiers.tsv
+++ b/data/test/test_public_identifiers.tsv
@@ -1,0 +1,6 @@
+sample_name	gisaid_name
+nextstrain_sample1	hCoV-19/USA/CA-CZB-01/2020
+nextstrain_sample2	hCoV-19/USA/CA-CZB-02/2020
+nextstrain_sample3	hCoV-19/USA/CA-CZB-03/2020
+nextstrain_sample4	hCoV-19/USA/CA-CZB-04/2020
+nextstrain_sample5	hCoV-19/USA/CA-CZB-05/2020

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,6 +11,8 @@ params {
   ref_gb = "$baseDir/data/MN908947.3.gb"
   primers = "$baseDir/data/SARS-COV-2_spikePrimers.bed"
 
+  public_identifiers = false
+
   single_end = false
   skip_trim_adapters = false
   readPaths = false

--- a/run_analysis.nf
+++ b/run_analysis.nf
@@ -601,7 +601,7 @@ if (params.nextstrain_sequences && params.nextstrain_ncov) {
     if (params.existing_alignment)
     """
     augur filter \
-          --sequences ${sequences}
+          --sequences ${sequences} \
           --metadata ${metadata} \
           --include-where division=California \
           --output CA_sequences.fasta

--- a/run_analysis.nf
+++ b/run_analysis.nf
@@ -12,6 +12,7 @@ def helpMessage() {
       --ref_gb                      Reference Genbank file for augur (default: data/MN908947.3.gb)
       --blast_sequences             FASTA of sequences for BLAST alignment
       --nextstrain_sequences        FASTA of sequences to build a tree with
+      --nextstrain_metadata         TSV from GISAID
       --minLength                   Minimum base pair length to allow assemblies to pass QC (default: 29000)
       --maxNs                       Max number of Ns to allow assemblies to pass QC (default: 100)
 
@@ -195,7 +196,7 @@ if (params.nextstrain_ncov) {
   if (nextstrain_ncov[-1] != "/") {
       nextstrain_ncov = nextstrain_ncov + "/"
   }
-  blast_metadata = file(nextstrain_ncov + "data/metadata.tsv", checkIfExists: true)
+  blast_metadata = file(params.nextstrain_metadata, checkIfExists: true)
   process findContextuals {
       tag {sampleName}
       publishDir "${params.outdir}/samples/${sampleName}", mode: 'copy'
@@ -411,7 +412,7 @@ if (params.nextstrain_sequences && params.nextstrain_ncov) {
       nextstrain_ncov = nextstrain_ncov + "/"
   }
 
-  nextstrain_metadata_path = file(nextstrain_ncov + "data/metadata.tsv", checkIfExists: true)
+  nextstrain_metadata_path = file(params.nextstrain_metadata, checkIfExists: true)
   nextstrain_config = nextstrain_ncov + "config/"
   include_file = file(nextstrain_config + "include.txt", checkIfExists: true)
   exclude_file = file(nextstrain_config + "exclude.txt", checkIfExists: true)

--- a/run_analysis.nf
+++ b/run_analysis.nf
@@ -592,6 +592,7 @@ if (params.nextstrain_sequences && params.nextstrain_ncov) {
     path(ref_gb)
     path(existing_alignment)
     path(sample_sequences) from sample_and_contextual_ch
+    path(metadata) from nextstrain_metadata
 
     output:
     path("aligned_raw.fasta") into (firstaligned_ch, makepriorities_ch, filterstrains_in)
@@ -599,7 +600,13 @@ if (params.nextstrain_sequences && params.nextstrain_ncov) {
     script:
     if (params.existing_alignment)
     """
+    augur filter \
+          --sequences ${sequences}
+          --metadata ${metadata} \
+          --include-where division=California \
+          --output CA_sequences.fasta
     cat ${sample_sequences} > sample_and_contextual.fasta
+    cat CA_sequences.fasta >> sample_and_contextual.fasta 
     augur align \
               --sequences sample_and_contextual.fasta \
               --reference-sequence ${ref_gb} \

--- a/run_analysis.nf
+++ b/run_analysis.nf
@@ -562,6 +562,27 @@ if (params.nextstrain_sequences && params.nextstrain_ncov) {
     existing_alignment = file(params.ref, checkIfExists: true)
   }
 
+  process includePreviousSequences {
+    publishDir "${params.outdir}/nextstrain/config", mode: 'copy'
+
+    input:
+    path(existing_alignment)
+    path(include) from nextstrain_include
+
+    output:
+    path("all_included_sequences.txt") into all_included_sequences
+
+    when:
+    params.existing_alignment
+
+    script:
+    """
+    cat ${existing_alignment} | grep '>' | awk -F '>' '{print \$2}' > existing_alignment_seqs.txt
+    cat ${include} existing_alignment_seqs.txt > intermediate.txt
+    sort intermediate.txt | uniq > all_included_sequences.txt
+    """
+  }
+
   process alignSequences {
     label "process_large"
     publishDir "${params.outdir}/nextstrain/results", mode: 'copy'


### PR DESCRIPTION
- This will pull all the CA sequences from the input nextstrain sequences so we always include newer CA sequences. 
- given a TSV with GISAID identifiers, samples will be renamed before going through the augur pipeline