### PR TITLE
Implement proper variant calling

### DIFF
--- a/call_consensus.nf
+++ b/call_consensus.nf
@@ -426,8 +426,13 @@ process computeStats {
     """
 }
 
-combined_variants_bams = combined_variants_bams.map { it[1] }.collect()
-individual_vcfs = individual_vcfs.map { it[1] }.collect()
+if (!params.joint_variant_calling) {
+    combined_variants_bams = Channel.empty()
+    individual_vcfs = Channel.empty()
+} else {
+    combined_variants_bams = combined_variants_bams.map { it[1] }.collect()
+    individual_vcfs = individual_vcfs.map { it[1] }.collect()
+}
 
 process combinedVariants {
     publishDir "${params.outdir}", mode: 'copy'
@@ -499,7 +504,6 @@ process filterAssemblies {
     input:
     path(merged_stats) from merged_stats_ch
     path(merged_assemblies) from merged_assemblies_ch
-    path(vcf) from combined_variants_vcf
 
     output:
     path("filtered.stats.tsv")
@@ -510,7 +514,6 @@ process filterAssemblies {
     filter_assemblies.py \
 	--max_n ${params.maxNs} --min_len ${params.minLength} \
 	--stats ${merged_stats} --fasta ${merged_assemblies} \
-	--vcf ${vcf} \
 	--out_prefix filtered
     """
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -27,4 +27,5 @@ params {
   fasta = 'https://github.com/czbiohub/test-datasets/raw/msspe/reference/MN908947.3.fa'
   ref_host = 'data/human_chr1.fa'
   primers = 'https://github.com/czbiohub/test-datasets/raw/msspe/reference/SARS-COV-2_spikePrimers.bed'
+  joint_variant_calling = true
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -58,13 +58,6 @@ params {
   group_by = 'division year month'
   existing_alignment = false
 
-
-// detect intrahost variants
-   intrahost_variants = false
-   intrahost_ploidy = 2
-   intrahost_min_frac = 0.2
-   intrahost_variants_cpu = 4
-
 // Output documentation
   multiqc_config = "$baseDir/assets/multiqc_config.yaml"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -58,6 +58,9 @@ params {
   group_by = 'division year month'
   existing_alignment = false
 
+// whether to create a joint VCF
+  joint_variant_calling = false
+
 // Output documentation
   multiqc_config = "$baseDir/assets/multiqc_config.yaml"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -105,36 +105,40 @@ def check_max(obj, type) {
 
 process {
 
-  cpus = { check_max( 2 * task.attempt, 'cpus') }
-  memory = { check_max( 4.GB * task.attempt, 'memory') }
-  time = { check_max( 1.h * task.attempt, 'time') }
+    cpus = { check_max( 2 * task.attempt, 'cpus') }
+    memory = { check_max( 4.GB * task.attempt, 'memory') }
+    time = { check_max( 1.h * task.attempt, 'time') }
 
-  errorStrategy = { task.attempt < 4 ? 'retry' : 'finish' }
-  maxRetries = 3
-  maxErrors = '-1'
+    errorStrategy = { task.attempt < 4 ? 'retry' : 'finish' }
+    maxRetries = 3
+    maxErrors = '-1'
 
-  container = 'czbiohub/sc2-msspe'
+    container = 'czbiohub/sc2-msspe'
 
-  withLabel:'process_large' {
-    cpus = { check_max(8 * task.attempt, 'cpus') }
-    memory = { check_max(16.GB * task.attempt, 'memory') }
-    time = { check_max (8.h * task.attempt, 'time')}
-  }
-  withLabel:'process_medium' {
-    cpus = { check_max(4 * task.attempt, 'cpus') }
-    memory = { check_max(8.GB * task.attempt, 'memory') }
-    time = { check_max (2.h * task.attempt, 'time')}
-  }
-  withLabel:'process_small' {
-    cpus = { check_max(2 * task.attempt, 'cpus') }
-    memory = { check_max(4.GB * task.attempt, 'memory') }
-    time = { check_max (1.h * task.attempt, 'time')}
-  }
-  withLabel:'process_tiny' {
-    cpus = { check_max(1 * task.attempt, 'cpus') }
-    memory = { check_max(2.GB * task.attempt, 'memory') }
-    time = { check_max (1.h * task.attempt, 'time')}
-  }
+    withLabel:'process_pileup' {
+        memory = { check_max(16.GB * task.attempt, 'memory') }
+        time = { check_max (8.h * task.attempt, 'time')}
+    }
+    withLabel:'process_large' {
+        cpus = { check_max(8 * task.attempt, 'cpus') }
+        memory = { check_max(16.GB * task.attempt, 'memory') }
+        time = { check_max (8.h * task.attempt, 'time')}
+    }
+    withLabel:'process_medium' {
+        cpus = { check_max(4 * task.attempt, 'cpus') }
+        memory = { check_max(8.GB * task.attempt, 'memory') }
+        time = { check_max (2.h * task.attempt, 'time')}
+    }
+    withLabel:'process_small' {
+        cpus = { check_max(2 * task.attempt, 'cpus') }
+        memory = { check_max(4.GB * task.attempt, 'memory') }
+        time = { check_max (1.h * task.attempt, 'time')}
+    }
+    withLabel:'process_tiny' {
+        cpus = { check_max(1 * task.attempt, 'cpus') }
+        memory = { check_max(2.GB * task.attempt, 'memory') }
+        time = { check_max (1.h * task.attempt, 'time')}
+    }
 
 }
 


### PR DESCRIPTION
This PR implements a proper variant calling pipeline, using bcftools to call variants from a pileup.

Previously, we simply aligned the consensus sequence back to the reference, and used that to "call variants". However, ambiguous IUPAC sites were being mislabeled as REF in the combined VCF.

Now, we do a second pileup on each sample to generate a VCF for it. Then, we do a combined joint pileup on all samples to generate the combined VCF. To save time, we only do the joint pileup on sites previously identified from the sample-specific VCFs.

This PR also removes the `realignConsensus` and `intrahostVariants` processes, as they aren't necessary and add code bloat.

Fixes #40.