### PR TITLE
Add --save_filtered_reads option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ jobs:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
         nxf_ver: ['19.10.0', '']
+        profile_flags: [
+        'test',
+        'test --save_filtered_reads',
+        'test_fasta_reads',
+        'test_single_end',
+        ]
     steps:
       - uses: actions/checkout@v2
       - name: Install Nextflow
@@ -28,4 +34,4 @@ jobs:
         run: |
           # TODO nf-core: You can customise CI pipeline run tests as required
           # (eg. adding multiple test runs with different parameters)
-          ${NXF_RUN} ${GITHUB_WORKSPACE} -profile test,docker
+          ${NXF_RUN} ${GITHUB_WORKSPACE} -profile docker,${{ matrix.profile_flags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
         nxf_ver: ['19.10.0', '']
         profile_flags: [
         'test',
-        'test --save_filtered_reads',
+        'test --skip_trim_adapters',
+        'test --skip_filter_ref',
+        'test --save_sars2_filtered_reads',
         'test_fasta_reads',
         'test_single_end',
         ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Pull docker image
         run: |
           docker pull czbiohub/sc2-msspe:dev && docker tag czbiohub/sc2-msspe:dev czbiohub/sc2-msspe:dev
-      - name: Run pipeline with test data (single-end fastq input)
+      - name: Run pipeline with ${{ matrix.profile_flags }}
         run: |
           # TODO nf-core: You can customise CI pipeline run tests as required
           # (eg. adding multiple test runs with different parameters)

--- a/conf/test_single_end.config
+++ b/conf/test_single_end.config
@@ -5,6 +5,10 @@ params {
         ['RR057e_00734_subsampled_R1', ['https://github.com/czbiohub/test-datasets/raw/olgabot/msspe--add-human-and-kraken/testdata/RR057e_00734_subsampled_R1.fastq.gz']]
     ]
 
+    max_cpus = 2
+    max_memory = 6.GB
+    max_time = 48.h
+
     outdir = 'results/test_single_end'
     fasta = 'https://github.com/czbiohub/test-datasets/raw/msspe/reference/MN908947.3.fa'
     ref_host = 'data/human_chr1.fa'

--- a/main.nf
+++ b/main.nf
@@ -24,7 +24,7 @@ def helpMessage() {
       --minLength                   Minimum base pair length to allow assemblies to pass QC
       --no_reads_quast              Run QUAST without aligning reads
       --ercc_fasta                  Default: data/ercc_sequences.fasta
-      --save_filtered_reads         Whether to save the host-filtered reads
+      --save_sars2_filtered_reads   Whether to save the host-filtered reads
 
     Other options:
       --outdir                      The output directory where the results will be saved
@@ -172,9 +172,9 @@ process filterReads {
     tag { sampleName }
     label 'process_large'
     // Don't create filtered-sars2-reads subfolder if flag not specified
-    publishDir path: { params.save_filtered_reads ? "${params.outdir}/filtered-sars2-reads" : params.outdir },
+    publishDir path: { params.save_sars2_filtered_reads ? "${params.outdir}/filtered-sars2-reads" : params.outdir },
       mode: 'copy',
-      saveAs: { params.save_filtered_reads ? it : null }
+      saveAs: { params.save_sars2_filtered_reads ? it : null }
 
     input:
     path(db) from kraken2_db.collect()

--- a/main.nf
+++ b/main.nf
@@ -24,7 +24,7 @@ def helpMessage() {
       --minLength                   Minimum base pair length to allow assemblies to pass QC
       --no_reads_quast              Run QUAST without aligning reads
       --ercc_fasta                  Default: data/ercc_sequences.fasta
-      --save_sars2_filtered_reads   Whether to save the host-filtered reads
+      --save_sars2_filtered_reads   Whether to save the reads filtered down to just SARS-CoV-2
 
     Other options:
       --outdir                      The output directory where the results will be saved

--- a/main.nf
+++ b/main.nf
@@ -24,6 +24,7 @@ def helpMessage() {
       --minLength                   Minimum base pair length to allow assemblies to pass QC
       --no_reads_quast              Run QUAST without aligning reads
       --ercc_fasta                  Default: data/ercc_sequences.fasta
+      --save_filtered_reads         Whether to save the host-filtered reads
 
     Other options:
       --outdir                      The output directory where the results will be saved
@@ -170,6 +171,10 @@ process quantifyERCCs {
 process filterReads {
     tag { sampleName }
     label 'process_large'
+    // Don't create filtered-sars2-reads subfolder if flag not specified
+    publishDir path: { params.save_filtered_reads ? "${params.outdir}/filtered-sars2-reads" : params.outdir },
+      mode: 'copy',
+      saveAs: { params.save_filtered_reads ? it : null }
 
     input:
     path(db) from kraken2_db.collect()

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,6 +16,7 @@ params {
   skip_trim_adapters = false
   skip_filter_ref = false
   readPaths = false
+  save_sars2_filtered_reads = false
 
   // TODO update path to non-olga branch
   qpcr_primers = "https://github.com/czbiohub/test-datasets/raw/olgabot/msspe--add-human-and-kraken/testdata/qpcr_primers.bed"


### PR DESCRIPTION
Add the option to save host-filtered reads for future benchmarking

## PR checklist

- [ ] This comment contains a description of changes (with reason)
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

