### PR TITLE
Remove pileup minimum depth

### DIFF
--- a/bin/alignment_assembly_stats.py
+++ b/bin/alignment_assembly_stats.py
@@ -45,7 +45,7 @@ if args.cleaned_bam:
     samfile = pysam.AlignmentFile(args.cleaned_bam, "rb")
     ref_len, = samfile.lengths
     depths = [0] * ref_len
-    for column in samfile.pileup():
+    for column in samfile.pileup(max_depth=0):
         depths[column.reference_pos] = column.nsegments
     depths = np.array(depths)
 

--- a/bin/alignment_assembly_stats.py
+++ b/bin/alignment_assembly_stats.py
@@ -5,6 +5,7 @@ import collections
 import json
 import re
 import subprocess
+import shlex
 import pysam
 from Bio import SeqIO
 import numpy as np
@@ -42,12 +43,11 @@ elif args.neighborfasta:
 
 
 if args.cleaned_bam:
-    samfile = pysam.AlignmentFile(args.cleaned_bam, "rb")
-    ref_len, = samfile.lengths
-    depths = [0] * ref_len
-    for column in samfile.pileup(max_depth=0):
-        depths[column.reference_pos] = column.nsegments
-    depths = np.array(depths)
+    depths = subprocess.run(
+        "samtools depth -aa -d 0 {} | awk {}".format(
+            shlex.quote(args.cleaned_bam), "'{print $3}'"),
+        shell=True, stdout=subprocess.PIPE).stdout
+    depths = np.array([int(d.strip()) for d in depths.decode().strip().split("\n")])
 
     stats["depth_avg"] = depths.mean()
     stats["depth_q.01"] = np.quantile(depths, .01)
@@ -61,7 +61,7 @@ if args.cleaned_bam:
     stats["depth_frac_above_50x"] = (depths >= 30).mean()
     stats["depth_frac_above_100x"] = (depths >= 100).mean()
 
-    ax = sns.lineplot(np.arange(1, ref_len+1), depths)
+    ax = sns.lineplot(np.arange(1, len(depths)+1), depths)
     ax.set_title(args.sample_name)
     ax.set(xlabel="position", ylabel="depth")
     plt.yscale("symlog")
@@ -71,7 +71,8 @@ seq, = SeqIO.parse(args.assembly, "fasta")
 stats["allele_counts"] = dict(collections.Counter(str(seq.seq)))
 
 if args.reads:
-    fq_lines = subprocess.run(" ".join(["zcat"] + list(args.reads)) + " | wc -l",
+    fq_lines = subprocess.run(" ".join(["zcat"] + [shlex.quote(r) for r in args.reads])
+                              + " | wc -l",
                               shell=True, stdout=subprocess.PIPE).stdout
     stats["total_reads"] = int(int(fq_lines) / 4)
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -19,7 +19,8 @@ params {
   readPaths = [
     ['sample1', ['https://github.com/czbiohub/test-datasets/raw/msspe/testdata/sample1_R1_001.fastq.gz', 'https://github.com/czbiohub/test-datasets/raw/msspe/testdata/sample1_R2_001.fastq.gz']],
     ['RR057e_00734_subsampled_R1', ['https://github.com/czbiohub/test-datasets/raw/olgabot/msspe--add-human-and-kraken/testdata/RR057e_00734_subsampled_R1.fastq.gz',
-                 'https://github.com/czbiohub/test-datasets/raw/olgabot/msspe--add-human-and-kraken/testdata/RR057e_00734_subsampled_R2.fastq.gz']]
+                 'https://github.com/czbiohub/test-datasets/raw/olgabot/msspe--add-human-and-kraken/testdata/RR057e_00734_subsampled_R2.fastq.gz']],
+    ['empty', ['https://github.com/czbiohub/test-datasets/raw/msspe/testdata/empty_R1.fastq.gz', 'https://github.com/czbiohub/test-datasets/raw/msspe/testdata/empty_R2.fastq.gz']]
   ]
   // originally from https://genexa.ch/sars2-bioinformatics-resources/
   kraken2_db = 'https://github.com/czbiohub/test-datasets/raw/olgabot/mssspe--kraken-coronavirus/reference/kraken_coronavirus_db_only.tar.gz'

--- a/main.nf
+++ b/main.nf
@@ -334,7 +334,7 @@ process makeConsensus {
   script:
   """
   samtools index ${bam}
-  samtools mpileup -A -d ${params.mpileupDepth} -Q0 ${bam} |
+  samtools mpileup -A -d 0 -Q0 ${bam} |
       ivar consensus -q ${params.ivarQualThreshold} -t ${params.ivarFreqThreshold} -m ${params.minDepth} -n N -p ${sampleName}.primertrimmed.consensus
   echo '>${sampleName}' > ${sampleName}.consensus.fa
   seqtk seq -l 50 ${sampleName}.primertrimmed.consensus.fa | tail -n +2 >> ${sampleName}.consensus.fa
@@ -389,7 +389,7 @@ process callVariants {
 
     script:
     """
-    bcftools mpileup -a FORMAT/AD -f ${ref_fasta} ${in_bams} |
+    bcftools mpileup -d 0 -a FORMAT/AD -f ${ref_fasta} ${in_bams} |
         bcftools call --ploidy 1 -m -P ${params.bcftoolsCallTheta} -v - |
         bcftools view -i 'DP>=${params.minDepth}' \
         > ${sampleName}.vcf
@@ -469,7 +469,7 @@ process combinedVariants {
     split -e -n l/${task.cpus} variant_positions.txt split_regions_
     ls split_regions_* |
         parallel -I % -j ${Math.ceil(task.cpus/2) as int} \
-        'bcftools mpileup -a FORMAT/DP,FORMAT/AD -f ${ref_fasta} \
+        'bcftools mpileup -d 0 -a FORMAT/DP,FORMAT/AD -f ${ref_fasta} \
         -R % ${in_bams} |
         bcftools call --ploidy 1 -m -P ${params.bcftoolsCallTheta} -v - \
         > %.vcf'

--- a/nextflow.config
+++ b/nextflow.config
@@ -37,7 +37,6 @@ params {
 // iVar defaults
   ivarQualThreshold = 20
   ivarFreqThreshold = 0.9
-  mpileupDepth = 10000
 
 // QUAST
   maxNs = 100


### PR DESCRIPTION
The minimum depth parameter in samtools pileup is approximate since it
discards whole reads (rather than applying the truncation separately
at each position the read spans). This appears to especially cause bad
behavior for some amplicon library preps, where overlapping regions
between amplicons can cause nearly all reads to be discarded at the 5'
end of an amplicon.

# czbiohub/sc2-msspe-bioinfo pull request

Many thanks for contributing to czbiohub/sc2-msspe-bioinfo!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

## PR checklist

- [x ] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [czbiohub/sc2-msspe-bioinfo branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/czbiohub/sc2-msspe-bioinfo)
- [x ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Documentation in `docs` is updated
- [ ] `CHANGELOG.md` is updated
- [ ] `README.md` is updated

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/czbiohub/sc2-msspe-bioinfo/tree/master/.github/CONTRIBUTING.md)
