### PR TITLE
add weblog scope to nextflow.config

### DIFF
--- a/conf/awsbatch.config
+++ b/conf/awsbatch.config
@@ -2,3 +2,8 @@ aws.region = 'us-west-2'
 process.executor = 'awsbatch'
 process.queue = 'covid-default-4ec31960-8b43-11ea-91fd-020934000518'
 aws.batch.cliPath = '/home/ec2-user/miniconda/bin/aws'
+
+weblog {
+  enabled = true
+  url = 'https://8o2jh1ss9d.execute-api.us-west-2.amazonaws.com/default/consensus_calling_endpoint_dev'
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -169,7 +169,3 @@ manifest {
   version = '1.0.0dev'
 }
 
-weblog {
-  enabled = true
-  url = 'https://8o2jh1ss9d.execute-api.us-west-2.amazonaws.com/default/consensus_calling_endpoint_dev'
-}

--- a/nextflow.config
+++ b/nextflow.config
@@ -168,3 +168,8 @@ manifest {
   nextflowVersion = '>=19.10.0'
   version = '1.0.0dev'
 }
+
+weblog {
+  enabled = true
+  url = 'https://8o2jh1ss9d.execute-api.us-west-2.amazonaws.com/default/consensus_calling_endpoint_dev'
+}


### PR DESCRIPTION
- always enable weblog to point to the URL `https://8o2jh1ss9d.execute-api.us-west-2.amazonaws.com/default/consensus_calling_endpoint_dev`
@jackkamm I put this in the `awsbatch` profile because we always run with that and this way we won't forget, but should I instead throw it into a `weblog` profile, where we run with `-profile awsbatch,weblog`? I decided it shouldn't go into the base config since then collaborators can't run it.