### PR TITLE
add -L option to raise cutoff to allow indel calling

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -409,7 +409,7 @@ process callVariants {
     // NOTE: we use samtools instead of bcftools mpileup because bcftools 1.9 ignores -d0
     script:
     """
-    samtools mpileup -aa -u -Q ${params.ivarQualThreshold} -d 0 -t AD -f ${ref_fasta} ${in_bams} |
+    samtools mpileup -aa -u -Q ${params.ivarQualThreshold} -d 0 -L 1000000 -t AD -f ${ref_fasta} ${in_bams} |
         bcftools call --ploidy 1 -m -P ${params.bcftoolsCallTheta} - \
         > ${sampleName}.full.vcf
     bgzip ${sampleName}.full.vcf


### PR DESCRIPTION
- [x ] This comment contains a description of changes (with reason)
- [x ] If you've fixed a bug or added code that should be tested, add tests!
- [x ] Ensure the test suite passes (`nextflow run . -profile test,docker`).

Added `-L 1000000` to enable INDEL calling in vcf generation (see [issue here](https://github.com/czbiohub/sc2-illumina-pipeline/issues/80)). Tested with seq69/70 data and tests in github actions. 